### PR TITLE
Update guide to fix missing --chain-id parameter

### DIFF
--- a/phase-3/challenges/create-poll.md
+++ b/phase-3/challenges/create-poll.md
@@ -17,6 +17,7 @@ desmoscli tx posts create "<Subspace>" "<Message>" true \
   --poll-answer <Second answer> \
   ...
   --from <your-key-name> --yes 
+  --chain-id <chain-id>
 ```
 
 Before seeing an example of such command, let's see what all the different parts of it do: 
@@ -39,6 +40,7 @@ desmoscli tx posts create "4e188d9c17150037d5199bbdb91ae1eb2a78a15aca04cb35530cc
   --poll-answer "Pug" \
   --poll-answer "German Sheperd" \
   --from jack --yes 
+  --chain-id morpheus-3000
 ```
 
 Once you've run that command you will be asked to type the password you've chosen during the setup and after having inserted it properly you should see something like this: 


### PR DESCRIPTION
ERROR: chain ID required but not specified